### PR TITLE
Allow non-recursive walking

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Useful to let network-drives remount, etc.
 A RegExp-instance the path to a file must match in order to  
 emit a "file" event. Set to ```null``` to emit all paths.
 
+```recursive``` (default: true)  
+Traverse in a recursive manner.  
+In case you wish to target only the current directory,  
+disable this.
+
 ### Properties
 
 maxPending  

--- a/lib/filewalker.js
+++ b/lib/filewalker.js
@@ -17,6 +17,8 @@ function Filewalker(root, options) {
   
   this.matchRegExp = null;
   
+  this.recursive = true;
+  
   options = options || {};
   Object.keys(options).forEach(function(k) {
     if(self.hasOwnProperty(k)) {
@@ -48,7 +50,7 @@ Filewalker.prototype._emitDir = function(p, s, fullPath) {
   fs.readdir(fullPath, function(err, files) {
     if(err) {
       self.error(err, self._emitDir, args);
-    } else {
+    } else if(self.recursive || !self.dirs) {
       files.forEach(function(file) {
         self.enqueue(self._stat, [path.join(fullPath, file)]);
       });

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -48,6 +48,9 @@ describe('Filewalker', function() {
     it('should have a .matchRegExp property <number>', function() {
       assert.strictEqual(fw.matchRegExp, null);
     });
+    it('should have a .recursive property <boolean>', function() {
+      assert.strictEqual(fw.recursive, true);
+    });
     it('should have a .walk() method', function() {
       assert.ok(fw.walk instanceof Function);
     });
@@ -329,6 +332,26 @@ describe('Filewalker', function() {
         assert.strictEqual(arguments.length, 0);
       });
       fw.on('done', done);
+      fw.walk();
+    });
+  });
+
+  describe('feature: non-recursive walking', function() {
+    var fw;
+    before(function() {
+      fw = filewalker(examplesDir, {recursive: false});
+    });
+    after(function() {
+      fw = null;
+    });
+
+    it('"done" event without recursive', function(done) {
+      fw.on('done', function() {
+        // it could be nicer to check the amount using fs on examplesDir
+        // this works, though, given the structure of /examples doesn't change
+        assert.strictEqual(this.files + this.dirs, 2);
+        done();
+      });
       fw.walk();
     });
   });


### PR DESCRIPTION
It is set as true by default. If set as false, it will traverse just the
root directory given.

Closes #2.
