### PR TITLE
Update filewalker.js to prevent usage of process.nextTick in later version of node

### DIFF
--- a/lib/filewalker.js
+++ b/lib/filewalker.js
@@ -1,10 +1,14 @@
-
 module.exports = Filewalker;
 
 var fs = require('fs'),
     path = require('path'),
     util = require('util'),
-    FunctionQueue = require('fqueue');
+    FunctionQueue = require('fqueue'),
+    immediately = process.nextTick;
+
+if (global.setImmediate !== undefined) {
+  immediately = global.setImmediate;
+};
 
 var lstat = process.platform === 'win32' ? 'stat' : 'lstat';
 
@@ -70,7 +74,7 @@ Filewalker.prototype._emitFile = function(p, s, fullPath) {
     this.enqueue(this._emitStream, [p, s, fullPath]);
   }
   
-  process.nextTick(function() {
+  immediately(function() {
     self.done();
   });
 };


### PR DESCRIPTION
in latest version of node process.nextTick gives following warning.

(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.

because of this sometimes code was breaking.
