### PR TITLE
Added readStreamOptions

### DIFF
--- a/lib/filewalker.js
+++ b/lib/filewalker.js
@@ -12,7 +12,7 @@ if (global.setImmediate !== undefined) {
 
 var lstat = process.platform === 'win32' ? 'stat' : 'lstat';
 
-function Filewalker(root, options) {
+function Filewalker(root, options, readStreamOptions) {
   if(!(this instanceof Filewalker)) return new Filewalker(root, options);
   
   FunctionQueue.call(this, options);
@@ -20,10 +20,23 @@ function Filewalker(root, options) {
   var self = this;
   
   this.matchRegExp = null;
-  
+
   this.recursive = true;
   
-  options = options || {};
+  this.readStreamOptions = {
+    flags: 'r',
+    encoding: null,
+    fd: null,
+    mode: 0666,
+    autoClose: true,
+    highWaterMark: 64 * 1024
+  };
+
+  for ( var i in readStreamOptions ) {
+    this.readStreamOptions[ i ] = readStreamOptions[ i ];
+  }
+
+  options = options || {}; 
   Object.keys(options).forEach(function(k) {
     if(self.hasOwnProperty(k)) {
       self[k] = options[k];
@@ -85,7 +98,7 @@ Filewalker.prototype._emitStream = function(p, s, fullPath) {
   
   this.open += 1;
   
-  var rs = fs.ReadStream(fullPath);
+  var rs = fs.ReadStream(fullPath, this.readStreamOptions);
   
   // retry on any error
   rs.on('error', function(err) {


### PR DESCRIPTION
To be able to configure the `ReadStream`, as mentioned in the [Issue 17](https://github.com/oleics/node-filewalker/issues/17), it was added an object `readStreamOptions` to `filewalker`s constructor:

```js
filewalker( path, options, readStreamOptions )
```
The third parameter is optional and it assumes `fs.createReadStream()`'s [default values](https://nodejs.org/api/fs.html#fs_fs_createreadstream_path_options).