### PR TITLE
Now options may have a 'readStream' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/filewalker.js
+++ b/lib/filewalker.js
@@ -12,7 +12,7 @@ if (global.setImmediate !== undefined) {
 
 var lstat = process.platform === 'win32' ? 'stat' : 'lstat';
 
-function Filewalker(root, options, readStreamOptions) {
+function Filewalker(root, options) {
   if(!(this instanceof Filewalker)) return new Filewalker(root, options);
   
   FunctionQueue.call(this, options);
@@ -22,8 +22,10 @@ function Filewalker(root, options, readStreamOptions) {
   this.matchRegExp = null;
 
   this.recursive = true;
+
+  options = options || {};
   
-  this.readStreamOptions = {
+  var readStreamOptions = {
     flags: 'r',
     encoding: null,
     fd: null,
@@ -32,13 +34,19 @@ function Filewalker(root, options, readStreamOptions) {
     highWaterMark: 64 * 1024
   };
 
-  for ( var i in readStreamOptions ) {
-    this.readStreamOptions[ i ] = readStreamOptions[ i ];
+  if ( ! options.readStream ) {
+    options.readStream = readStreamOptions;
+  } else {
+    // Overwrite only the specified properties
+    for ( var i in options.readStream ) {
+      readStreamOptions[ i ] = options.readStream[ i ];
+    }
+    options.readStream = readStreamOptions;
   }
-
-  options = options || {}; 
+  
+  // Copy all the options properties to this, except 'readStream'
   Object.keys(options).forEach(function(k) {
-    if(self.hasOwnProperty(k)) {
+    if( k !== 'readStream' && self.hasOwnProperty(k) ) {
       self[k] = options[k];
     }
   });
@@ -98,7 +106,7 @@ Filewalker.prototype._emitStream = function(p, s, fullPath) {
   
   this.open += 1;
   
-  var rs = fs.ReadStream(fullPath, this.readStreamOptions);
+  var rs = fs.ReadStream(fullPath, this.readStream);
   
   // retry on any error
   rs.on('error', function(err) {

--- a/lib/filewalker.js
+++ b/lib/filewalker.js
@@ -43,10 +43,12 @@ function Filewalker(root, options) {
     }
     options.readStream = readStreamOptions;
   }
+
+  this.readStream = options.readStream;
   
   // Copy all the options properties to this, except 'readStream'
   Object.keys(options).forEach(function(k) {
-    if( k !== 'readStream' && self.hasOwnProperty(k) ) {
+    if( self.hasOwnProperty(k) ) {
       self[k] = options[k];
     }
   });

--- a/lib/filewalker.js
+++ b/lib/filewalker.js
@@ -12,7 +12,7 @@ if (global.setImmediate !== undefined) {
 
 var lstat = process.platform === 'win32' ? 'stat' : 'lstat';
 
-function Filewalker(root, options) {
+function Filewalker(root, options, readStreamOptions) {
   if(!(this instanceof Filewalker)) return new Filewalker(root, options);
   
   FunctionQueue.call(this, options);
@@ -20,10 +20,23 @@ function Filewalker(root, options) {
   var self = this;
   
   this.matchRegExp = null;
-  
+
   this.recursive = true;
   
-  options = options || {};
+  this.readStreamOptions = {
+    flags: 'r',
+    encoding: null,
+    fd: null,
+    mode: 0666,
+    autoClose: true,
+    highWaterMark: 64 * 1024
+  };
+
+  for ( var i in readStreamOptions ) {
+    this.readStreamOptions[ i ] = readStreamOptions[ i ];
+  }
+
+  options = options || {}; 
   Object.keys(options).forEach(function(k) {
     if(self.hasOwnProperty(k)) {
       self[k] = options[k];
@@ -85,7 +98,7 @@ Filewalker.prototype._emitStream = function(p, s, fullPath) {
   
   this.open += 1;
   
-  var rs = fs.ReadStream(fullPath);
+  var rs = fs.ReadStream(fullPath, this.readStreamOptions);
   
   // retry on any error
   rs.on('error', function(err) {

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -369,4 +369,24 @@ describe('Filewalker', function() {
       fw.walk();
     });
   });
+
+  describe('feature: use given readStream options', function() {
+      var myHighWaterMark = 1024*1024;
+      var fw;
+      before(function() {
+        fw = filewalker(examplesFile, { readStream: { highWaterMark: myHighWaterMark } } );
+      });
+      after(function() {
+        fw = null;
+      });      
+      it('when "stream", it should be using the given readStream option', function(done) {
+        fw.on('stream', function(rs, p, s, fullPath) {
+          assert.strictEqual( rs.highWaterMark, fw.highWaterMark );
+          reallyReadTheReadStream(rs);
+        });
+        fw.on('done', done);
+        fw.walk();
+      });      
+
+  });
 });

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -381,7 +381,8 @@ describe('Filewalker', function() {
       });      
       it('when "stream", it should be using the given readStream option', function(done) {
         fw.on('stream', function(rs, p, s, fullPath) {
-          assert.strictEqual( rs.highWaterMark, fw.highWaterMark );
+          assert.strictEqual( fw.readStream.highWaterMark, myHighWaterMark );
+          assert.strictEqual( fw.readStream.highWaterMark, rs._readableState.highWaterMark );
           reallyReadTheReadStream(rs);
         });
         fw.on('done', done);


### PR DESCRIPTION
This replaces the [PR 18](https://github.com/oleics/node-filewalker/pull/18). As mentioned in [Issue 17](https://github.com/oleics/node-filewalker/issues/17), but now `readStream` may be included in options, instead of being passed as an argument to filewalker.

```js
var options = {
  readStream: {
    highWaterMark: 1024 * 1024 // 1 MB
  }
};
filewalker( path, options );
```
A test case was also included (in `basic-test.js`).